### PR TITLE
Fixes typo in CSS properties

### DIFF
--- a/src/components/Example/Example.jsx
+++ b/src/components/Example/Example.jsx
@@ -14,7 +14,7 @@ export default () => {
 
   return (
     <Example>
-      <Box display="flex" alignItems="centeru">
+      <Box display="flex" alignItems="center">
         <Logo width="50px" height="50px" />
         {greeting}
       </Box>


### PR DESCRIPTION
`"centeru"` -> `"center"`