### PR TITLE
Added Good Block extension on README examples list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@
 
 ## 👨‍💻 Examples
 
-You can look at [Framer](https://github.com/ElForastero/framer) todo list extension as an example of using this boilerplate. There are no straight restrictions on how to use it, or any limitations on tools and technologies. Think of it as a regular react application with some special properties.
+You can look at:
+
+- [Framer](https://github.com/ElForastero/framer): a todo list extension as an example of using this boilerplate.
+- [Good Block](https://github.com/LucasAndrad/block-sites-react-extension): an extension to block websites, also using this boilerplate.
+
+There are no straight restrictions on how to use it, or any limitations on tools and technologies. Think of it as a regular react application with some special properties.
 
 ## 📝 Description
 


### PR DESCRIPTION
**In this PR**

- I added my extension, [Good Block](https://github.com/LucasAndrad/block-sites-react-extension), on the README examples section.